### PR TITLE
Redirect spam.orain.org to localhost

### DIFF
--- a/zones/orain.org
+++ b/zones/orain.org
@@ -54,3 +54,6 @@ lists	A	178.62.57.223
 	AAAA	2a03:b0c0:1:d0::13d:a001
 mail	A	178.62.57.223
 	AAAA	2a03:b0c0:1:d0::13d:a001
+
+; Other
+spam	A	127.0.0.1


### PR DESCRIPTION
This avoid billions of spam bots hitting our services